### PR TITLE
Integrate SimCadenceController into ML Agents plugin

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -1,0 +1,7 @@
+[/Script/Engine.Engine]
+GameEngine=/Script/SimCadenceController.TrainingGameEngine
+
+[/Script/UnrealEd.EditorEngine]
+EditorEngine=/Script/SimCadenceController.TrainingEditorEngine
+
+r.VSyncEditor=0

--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -1,0 +1,9 @@
+[/Script/SimCadenceController.SimCadenceSettings]
+Mode=Realtime
+FixedHz=60.0
+bUncapRealtimeRendering=True
+bEnablePhysicsSubstepping=True
+bUncapInTraining=True
+TrainingRenderCapHz=60.0
+bDisableAudioInTraining=True
+bVerboseLogs=False

--- a/Source/SimCadenceController/Private/SimCadenceControllerModule.cpp
+++ b/Source/SimCadenceController/Private/SimCadenceControllerModule.cpp
@@ -1,0 +1,36 @@
+#include "SimCadenceControllerModule.h"
+#include "Modules/ModuleManager.h"
+#if WITH_EDITOR
+	#include "ISettingsModule.h"
+	#include "SimCadenceSettings.h"
+	#define LOCTEXT_NAMESPACE "FSimCadenceControllerModule"
+#endif
+
+IMPLEMENT_MODULE(FSimCadenceControllerModule, SimCadenceController)
+
+void FSimCadenceControllerModule::StartupModule()
+{
+#if WITH_EDITOR
+	if (ISettingsModule* SettingsModule = FModuleManager::LoadModulePtr<ISettingsModule>(TEXT("Settings")))
+	{
+		SettingsModule->RegisterSettings(TEXT("Project"), TEXT("Plugins"), TEXT("SimCadence"),
+			LOCTEXT("SimCadenceName", "Sim Cadence"),
+			LOCTEXT("SimCadenceDesc", "Physics-authoritative cadence and training controls."),
+			GetMutableDefault<USimCadenceSettings>());
+	}
+#endif
+}
+
+void FSimCadenceControllerModule::ShutdownModule()
+{
+#if WITH_EDITOR
+	if (ISettingsModule* SettingsModule = FModuleManager::LoadModulePtr<ISettingsModule>(TEXT("Settings")))
+	{
+		SettingsModule->UnregisterSettings(TEXT("Project"), TEXT("Plugins"), TEXT("SimCadence"));
+	}
+#endif
+}
+
+#if WITH_EDITOR
+	#undef LOCTEXT_NAMESPACE
+#endif

--- a/Source/SimCadenceController/Private/SimCadenceEngineSubsystem.cpp
+++ b/Source/SimCadenceController/Private/SimCadenceEngineSubsystem.cpp
@@ -1,0 +1,216 @@
+#include "SimCadenceEngineSubsystem.h"
+#include "SimCadenceSettings.h"
+#include "SimFixedCustomTimeStep.h"
+#include "Engine/Engine.h"
+#include "Engine/GameEngine.h"
+#include "Engine/World.h"
+#include "HAL/IConsoleManager.h"
+#include "PhysicsEngine/PhysicsSettings.h"
+#include "SimCadencePhysicsBridge.h"
+
+static void SetCVarIfPresent(const TCHAR* Name, int32 Value)
+{
+	if (IConsoleVariable* Var = IConsoleManager::Get().FindConsoleVariable(Name))
+	{
+		Var->Set(Value, ECVF_SetByCode);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Verbose, TEXT("[SimCadence] CVar '%s' not found at init; skipping."), Name);
+	}
+}
+
+void USimCadenceEngineSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	ApplyFromSettings();
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+
+	WorldInitHandle =
+		FWorldDelegates::OnPostWorldInitialization.AddUObject(this, &USimCadenceEngineSubsystem::OnWorldInit);
+	WorldCleanupHandle =
+		FWorldDelegates::OnWorldCleanup.AddUObject(this, &USimCadenceEngineSubsystem::OnWorldDestroyed);
+
+	switch (S->Mode)
+	{
+		case ESimCadenceMode::Realtime:
+			ApplyRealtimeMode();
+			break;
+		case ESimCadenceMode::TrainingRendered:
+			ApplyTrainingMode(false);
+			break;
+		case ESimCadenceMode::TrainingHeadless:
+			ApplyTrainingMode(true);
+			break;
+	}
+}
+
+void USimCadenceEngineSubsystem::ApplyFromSettings()
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	switch (S->Mode)
+	{
+		case ESimCadenceMode::Realtime:
+			ApplyRealtimeMode();
+			break;
+		case ESimCadenceMode::TrainingRendered:
+			ApplyTrainingMode(false);
+			break;
+		case ESimCadenceMode::TrainingHeadless:
+			ApplyTrainingMode(true);
+			break;
+	}
+}
+
+void USimCadenceEngineSubsystem::ReapplyFromSettings()
+{
+	ApplyFromSettings();
+}
+
+void USimCadenceEngineSubsystem::Deinitialize()
+{
+	if (WorldInitHandle.IsValid())
+	{
+		FWorldDelegates::OnPostWorldInitialization.Remove(WorldInitHandle);
+	}
+	if (WorldCleanupHandle.IsValid())
+	{
+		FWorldDelegates::OnWorldCleanup.Remove(WorldCleanupHandle);
+	}
+	RemoveCustomTimeStep();
+}
+
+bool USimCadenceEngineSubsystem::ShouldSubmitFrame()
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	const double			   Now = FPlatformTime::Seconds();
+
+	if (S->Mode == ESimCadenceMode::TrainingHeadless)
+	{
+		return false;
+	}
+
+	if (PresentInterval <= 0.0)
+	{
+		return true;
+	}
+
+	if (Now - LastPresentedTime >= PresentInterval)
+	{
+		LastPresentedTime = Now;
+		return true;
+	}
+	return false;
+}
+
+void USimCadenceEngineSubsystem::ApplyRealtimeMode()
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+
+	RemoveCustomTimeStep();
+
+	if (S->bUncapRealtimeRendering)
+	{
+		SetCVarIfPresent(TEXT("r.VSync"), 0);
+		SetCVarIfPresent(TEXT("t.MaxFPS"), 0);
+	}
+
+	ConfigurePhysicsSubstepping();
+
+	PresentInterval = 0.0;
+}
+
+void USimCadenceEngineSubsystem::ApplyTrainingMode(bool bHeadless)
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+
+	InstallCustomTimeStep();
+
+	if (bHeadless)
+	{
+		PresentInterval = -1.0;
+	}
+	else
+	{
+		if (S->bUncapInTraining)
+		{
+			PresentInterval = 0.0;
+		}
+		else
+		{
+			PresentInterval = 1.0 / FMath::Max(1.f, S->TrainingRenderCapHz);
+		}
+	}
+
+	SetCVarIfPresent(TEXT("r.VSync"), 0);
+	SetCVarIfPresent(TEXT("t.MaxFPS"), 0);
+
+	if (S->bDisableAudioInTraining)
+	{
+		SetCVarIfPresent(TEXT("au.RenderAudio"), 0);
+	}
+}
+
+void USimCadenceEngineSubsystem::InstallCustomTimeStep()
+{
+	if (GEngine && !CustomTS.IsValid())
+	{
+		USimFixedCustomTimeStep* NewTS = NewObject<USimFixedCustomTimeStep>(GEngine);
+		GEngine->SetCustomTimeStep(NewTS);
+		CustomTS = NewTS;
+	}
+}
+
+void USimCadenceEngineSubsystem::RemoveCustomTimeStep()
+{
+	if (GEngine)
+	{
+		GEngine->SetCustomTimeStep(nullptr);
+	}
+	CustomTS.Reset();
+	FApp::SetUseFixedTimeStep(false);
+}
+
+void USimCadenceEngineSubsystem::ConfigurePhysicsSubstepping()
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	if (UPhysicsSettings* PS = UPhysicsSettings::Get())
+	{
+		if (S->bEnablePhysicsSubstepping)
+		{
+			PS->bSubstepping = true;
+			PS->MaxSubstepDeltaTime = 1.0f / FMath::Max(1.f, S->FixedHz);
+			PS->MaxSubsteps = 8;
+		}
+	}
+}
+
+void USimCadenceEngineSubsystem::OnWorldInit(UWorld* World, const UWorld::InitializationValues IVS)
+{
+	if (!World || World->IsPreviewWorld())
+		return;
+	ApplyFromSettings();
+	GetOrSpawnPhysicsBridge(World);
+}
+
+void USimCadenceEngineSubsystem::OnWorldDestroyed(UWorld* World, bool bSessionEnded, bool bCleanupResources)
+{
+	Bridges.Remove(World);
+}
+
+ASimCadencePhysicsBridge* USimCadenceEngineSubsystem::GetOrSpawnPhysicsBridge(UWorld* World)
+{
+	if (!World)
+		return nullptr;
+	if (TWeakObjectPtr<ASimCadencePhysicsBridge>* Found = Bridges.Find(World))
+	{
+		return Found->Get();
+	}
+
+	FActorSpawnParameters SP;
+	SP.ObjectFlags = RF_Transient;
+	SP.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+	ASimCadencePhysicsBridge* Bridge =
+		World->SpawnActor<ASimCadencePhysicsBridge>(ASimCadencePhysicsBridge::StaticClass());
+	Bridges.Add(World, Bridge);
+	return Bridge;
+}

--- a/Source/SimCadenceController/Private/SimCadencePhysicsBridge.cpp
+++ b/Source/SimCadenceController/Private/SimCadencePhysicsBridge.cpp
@@ -1,0 +1,34 @@
+#include "SimCadencePhysicsBridge.h"
+#include "SimCadenceSettings.h"
+#include "Async/Async.h"
+
+ASimCadencePhysicsBridge::ASimCadencePhysicsBridge()
+{
+	PrimaryActorTick.bCanEverTick = false;
+	bAsyncPhysicsTickEnabled = true;
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	FixedDeltaSeconds = 1.0 / FMath::Max(1.f, S->FixedHz);
+}
+
+void ASimCadencePhysicsBridge::BeginPlay()
+{
+	Super::BeginPlay();
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	FixedDeltaSeconds = 1.0 / FMath::Max(1.f, S->FixedHz);
+}
+
+void ASimCadencePhysicsBridge::AsyncPhysicsTickActor(float DeltaTime, float SimTime)
+{
+	Accumulator += DeltaTime;
+	while (Accumulator + KINDA_SMALL_NUMBER >= FixedDeltaSeconds)
+	{
+		Accumulator -= FixedDeltaSeconds;
+		const float Step = (float)FixedDeltaSeconds;
+		AsyncTask(ENamedThreads::GameThread, [this, Step]() {
+			if (IsValid(this))
+			{
+				OnFixedStep.Broadcast(Step);
+			}
+		});
+	}
+}

--- a/Source/SimCadenceController/Private/SimCadenceSettings.cpp
+++ b/Source/SimCadenceController/Private/SimCadenceSettings.cpp
@@ -1,0 +1,17 @@
+#include "SimCadenceSettings.h"
+#include "SimCadenceEngineSubsystem.h"
+#include "Engine/Engine.h"
+
+#if WITH_EDITOR
+void USimCadenceSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+	if (GEngine)
+	{
+		if (USimCadenceEngineSubsystem* Sub = GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>())
+		{
+			Sub->ReapplyFromSettings();
+		}
+	}
+}
+#endif

--- a/Source/SimCadenceController/Private/SimFixedCustomTimeStep.cpp
+++ b/Source/SimCadenceController/Private/SimFixedCustomTimeStep.cpp
@@ -1,0 +1,34 @@
+#include "SimFixedCustomTimeStep.h"
+#include "SimCadenceSettings.h"
+#include "Misc/App.h"
+
+USimFixedCustomTimeStep::USimFixedCustomTimeStep()
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	FixedDeltaSeconds = 1.0 / FMath::Max(1.f, S->FixedHz);
+}
+
+bool USimFixedCustomTimeStep::Initialize(UEngine* InEngine)
+{
+	FApp::SetUseFixedTimeStep(true);
+	FApp::SetFixedDeltaTime(FixedDeltaSeconds);
+	return true;
+}
+
+void USimFixedCustomTimeStep::Shutdown(UEngine* InEngine)
+{
+	FApp::SetUseFixedTimeStep(false);
+}
+
+bool USimFixedCustomTimeStep::UpdateTimeStep(UEngine* InEngine)
+{
+	const USimCadenceSettings* S = USimCadenceSettings::Get();
+	const double			   Target = 1.0 / FMath::Max(1.f, S->FixedHz);
+	if (Target != FixedDeltaSeconds)
+	{
+		FixedDeltaSeconds = Target;
+		FApp::SetFixedDeltaTime(FixedDeltaSeconds);
+	}
+	// Training never sleeps; engine runs as fast as possible.
+	return true;
+}

--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,0 +1,15 @@
+#if WITH_EDITOR
+	#include "TrainingEditorEngine.h"
+	#include "SimCadenceEngineSubsystem.h"
+	#include "Engine/Engine.h"
+
+void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
+{
+	bool bPresent = bShouldPresent;
+	if (USimCadenceEngineSubsystem* Sub = GEngine ? GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>() : nullptr)
+	{
+		bPresent = Sub->ShouldSubmitFrame();
+	}
+	Super::RedrawViewports(bPresent);
+}
+#endif // WITH_EDITOR

--- a/Source/SimCadenceController/Private/TrainingGameEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingGameEngine.cpp
@@ -1,0 +1,13 @@
+#include "TrainingGameEngine.h"
+#include "SimCadenceEngineSubsystem.h"
+#include "Engine/Engine.h"
+
+void UTrainingGameEngine::RedrawViewports(bool bShouldPresent)
+{
+	bool bPresent = bShouldPresent;
+	if (USimCadenceEngineSubsystem* Sub = GEngine ? GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>() : nullptr)
+	{
+		bPresent = Sub->ShouldSubmitFrame();
+	}
+	Super::RedrawViewports(bPresent);
+}

--- a/Source/SimCadenceController/Public/SimCadenceControllerModule.h
+++ b/Source/SimCadenceController/Public/SimCadenceControllerModule.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Modules/ModuleManager.h"
+
+class FSimCadenceControllerModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/Source/SimCadenceController/Public/SimCadenceEngineSubsystem.h
+++ b/Source/SimCadenceController/Public/SimCadenceEngineSubsystem.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Subsystems/EngineSubsystem.h"
+#include "SimCadenceEngineSubsystem.generated.h"
+
+class USimFixedCustomTimeStep;
+class ASimCadencePhysicsBridge;
+
+UCLASS()
+class SIMCADENCECONTROLLER_API USimCadenceEngineSubsystem : public UEngineSubsystem
+{
+	GENERATED_BODY()
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	UFUNCTION(BlueprintCallable, Category = "SimCadence")
+	void		 ReapplyFromSettings();
+	virtual void Deinitialize() override;
+
+	bool ShouldSubmitFrame();
+
+	UFUNCTION(BlueprintCallable, Category = "SimCadence")
+	ASimCadencePhysicsBridge* GetOrSpawnPhysicsBridge(UWorld* World);
+
+private:
+	void ApplyRealtimeMode();
+	void ApplyFromSettings();
+	void ApplyTrainingMode(bool bHeadless);
+	void InstallCustomTimeStep();
+	void RemoveCustomTimeStep();
+	void ConfigurePhysicsSubstepping();
+	void OnWorldInit(UWorld* World, const UWorld::InitializationValues IVS);
+	void OnWorldDestroyed(UWorld* World, bool bSessionEnded, bool bCleanupResources);
+
+private:
+	TWeakObjectPtr<USimFixedCustomTimeStep> CustomTS;
+	double									LastPresentedTime = 0.0;
+	double									PresentInterval = 0.0;
+
+	FDelegateHandle WorldInitHandle;
+	FDelegateHandle WorldCleanupHandle;
+
+	TMap<TWeakObjectPtr<UWorld>, TWeakObjectPtr<ASimCadencePhysicsBridge>> Bridges;
+};

--- a/Source/SimCadenceController/Public/SimCadencePhysicsBridge.h
+++ b/Source/SimCadenceController/Public/SimCadencePhysicsBridge.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "SimCadencePhysicsBridge.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FFixedStepEvent, float, FixedDeltaTime);
+
+UCLASS(NotBlueprintable, Transient)
+class SIMCADENCECONTROLLER_API ASimCadencePhysicsBridge : public AActor
+{
+	GENERATED_BODY()
+public:
+	ASimCadencePhysicsBridge();
+
+	virtual bool ShouldTickIfViewportsOnly() const override { return true; }
+	virtual void BeginPlay() override;
+	virtual void AsyncPhysicsTickActor(float DeltaTime, float SimTime) override;
+
+	UPROPERTY(BlueprintAssignable, Category = "SimCadence")
+	FFixedStepEvent OnFixedStep;
+
+private:
+	double Accumulator = 0.0;
+	double FixedDeltaSeconds = 1.0 / 60.0;
+};

--- a/Source/SimCadenceController/Public/SimCadenceSettings.h
+++ b/Source/SimCadenceController/Public/SimCadenceSettings.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "SimCadenceSettings.generated.h"
+
+UENUM(BlueprintType)
+enum class ESimCadenceMode : uint8
+{
+	Realtime		 UMETA(DisplayName = "Realtime"),
+	TrainingRendered UMETA(DisplayName = "Training Rendered"),
+	TrainingHeadless UMETA(DisplayName = "Training Headless")
+};
+
+UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "Sim Cadence"))
+class SIMCADENCECONTROLLER_API USimCadenceSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "General", meta = (ClampMin = "1.0"))
+	float FixedHz = 60.f;
+
+	UPROPERTY(EditAnywhere, Config, Category = "General")
+	ESimCadenceMode Mode = ESimCadenceMode::Realtime;
+
+	// Realtime
+	UPROPERTY(EditAnywhere, Config, Category = "Realtime")
+	bool bUncapRealtimeRendering = true;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Realtime",
+		meta = (ToolTip = "Enable Chaos substepping and set MaxSubstepDeltaTime = 1/FixedHz"))
+	bool bEnablePhysicsSubstepping = true;
+
+	// Training
+	UPROPERTY(EditAnywhere, Config, Category = "Training")
+	bool bUncapInTraining = true;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Training", meta = (ClampMin = "1.0"))
+	float TrainingRenderCapHz = 60.f;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Training")
+	bool bDisableAudioInTraining = true;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Logging")
+	bool bVerboseLogs = false;
+
+	static const USimCadenceSettings* Get() { return GetDefault<USimCadenceSettings>(); }
+
+#if WITH_EDITOR
+public:
+	virtual FName GetContainerName() const override { return TEXT("Project"); }	 // Project Settings
+	virtual FName GetCategoryName() const override { return TEXT("Plugins"); }	 // Category in sidebar
+	virtual FName GetSectionName() const override { return TEXT("SimCadence"); } // Entry label
+	virtual FText GetSectionText() const override { return FText::FromString(TEXT("Sim Cadence")); }
+	virtual FText GetSectionDescription() const override
+	{
+		return FText::FromString(TEXT("Physics-authoritative cadence and training controls."));
+	}
+	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
+};

--- a/Source/SimCadenceController/Public/SimFixedCustomTimeStep.h
+++ b/Source/SimCadenceController/Public/SimFixedCustomTimeStep.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Engine/EngineCustomTimeStep.h"
+#include "SimFixedCustomTimeStep.generated.h"
+
+UCLASS()
+class SIMCADENCECONTROLLER_API USimFixedCustomTimeStep : public UEngineCustomTimeStep
+{
+	GENERATED_BODY()
+public:
+	USimFixedCustomTimeStep();
+
+	virtual bool Initialize(class UEngine* InEngine) override;
+	virtual void Shutdown(class UEngine* InEngine) override;
+	virtual bool UpdateTimeStep(class UEngine* InEngine) override;
+
+private:
+	double FixedDeltaSeconds = 1.0 / 60.0;
+};

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,0 +1,14 @@
+#if WITH_EDITOR
+	#pragma once
+	#include "CoreMinimal.h"
+	#include "Editor/EditorEngine.h"
+	#include "TrainingEditorEngine.generated.h"
+
+UCLASS(config = Engine)
+class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
+{
+	GENERATED_BODY()
+protected:
+	virtual void RedrawViewports(bool bShouldPresent) override;
+};
+#endif // WITH_EDITOR

--- a/Source/SimCadenceController/Public/TrainingGameEngine.h
+++ b/Source/SimCadenceController/Public/TrainingGameEngine.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Engine/GameEngine.h"
+#include "TrainingGameEngine.generated.h"
+
+UCLASS(config = Engine)
+class SIMCADENCECONTROLLER_API UTrainingGameEngine : public UGameEngine
+{
+	GENERATED_BODY()
+protected:
+	virtual void RedrawViewports(bool bShouldPresent) override;
+};

--- a/Source/SimCadenceController/SimCadenceController.Build.cs
+++ b/Source/SimCadenceController/SimCadenceController.Build.cs
@@ -1,0 +1,20 @@
+using UnrealBuildTool;
+
+public class SimCadenceController : ModuleRules
+{
+	public SimCadenceController(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(
+			new string[] { "Core", "CoreUObject", "Engine", "Projects", "DeveloperSettings" });
+
+		PrivateDependencyModuleNames.AddRange(
+			new string[] { "Slate", "SlateCore", "InputCore", "RenderCore", "RHI", "PhysicsCore" });
+
+		if (Target.bBuildEditor)
+		{
+			PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd", "Settings" });
+		}
+	}
+}

--- a/Source/UnrealMLAgents/Public/UnrealMLAgents/Academy.h
+++ b/Source/UnrealMLAgents/Public/UnrealMLAgents/Academy.h
@@ -11,6 +11,8 @@
 #include "Tickable.h"
 #include "Academy.generated.h"
 
+class ASimCadencePhysicsBridge;
+
 // Define the delegate types
 /**
  * @brief Delegate triggered when the action decision-making process is initiated.
@@ -256,6 +258,18 @@ private:
 	/// Communicator used for interacting with remote agents or policies.
 	UPROPERTY()
 	URpcCommunicator* RpcCommunicator;
+
+	/// Whether stepping is driven by the physics fixed step.
+	bool bUsePhysicsStep = false;
+
+	/// Bridge providing fixed-step callbacks.
+	TWeakObjectPtr<ASimCadencePhysicsBridge> BoundBridge;
+
+	/**
+	 * @brief Handles physics fixed step events.
+	 */
+	UFUNCTION()
+	void HandleFixedStep(float FixedDt);
 
 	/**
 	 * @brief Lazily initializes the Academy.

--- a/Source/UnrealMLAgents/UnrealMLAgents.Build.cs
+++ b/Source/UnrealMLAgents/UnrealMLAgents.Build.cs
@@ -16,7 +16,8 @@ public class UnrealMLAgents : ModuleRules
 		MLAgentsPlatformInstance = GetMLAgentsPlatformInstance(Target);
 		bEnableExceptions = true;
 
-		PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore", "Core", "CoreUObject", "Engine" });
+		PrivateDependencyModuleNames.AddRange(
+			new string[] { "Slate", "SlateCore", "Core", "CoreUObject", "Engine", "SimCadenceController" });
 
 		if (Target.bBuildEditor)
 		{

--- a/UnrealMLAgents.uplugin
+++ b/UnrealMLAgents.uplugin
@@ -15,14 +15,19 @@
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
-	"Modules": [
-		{
-			"name": "UnrealMLAgents",
-			"type": "Runtime",
-			"loadingphase": "Default",
-			"PlatformAllowList": [
-				"Win64"
-			]
-		}
-	]
+        "Modules": [
+                {
+                        "name": "UnrealMLAgents",
+                        "type": "Runtime",
+                        "loadingphase": "Default",
+                        "PlatformAllowList": [
+                                "Win64"
+                        ]
+                },
+                {
+                        "name": "SimCadenceController",
+                        "type": "Runtime",
+                        "loadingphase": "Default"
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- add SimCadenceController module and configs
- drive Academy steps from SimCadence fixed physics ticks
- expose training engine overrides for consistent physics cadence

## Testing
- `pre-commit run --files Source/UnrealMLAgents/Private/Academy.cpp Source/UnrealMLAgents/Public/UnrealMLAgents/Academy.h Source/UnrealMLAgents/UnrealMLAgents.Build.cs UnrealMLAgents.uplugin Config/DefaultGame.ini Config/DefaultEngine.ini Source/SimCadenceController/Private/TrainingGameEngine.cpp Source/SimCadenceController/Private/TrainingEditorEngine.cpp Source/SimCadenceController/Private/SimFixedCustomTimeStep.cpp Source/SimCadenceController/Private/SimCadenceControllerModule.cpp Source/SimCadenceController/Private/SimCadenceSettings.cpp Source/SimCadenceController/Private/SimCadenceEngineSubsystem.cpp Source/SimCadenceController/Private/SimCadencePhysicsBridge.cpp Source/SimCadenceController/Public/SimCadencePhysicsBridge.h Source/SimCadenceController/Public/SimFixedCustomTimeStep.h Source/SimCadenceController/Public/TrainingEditorEngine.h Source/SimCadenceController/Public/SimCadenceEngineSubsystem.h Source/SimCadenceController/Public/TrainingGameEngine.h Source/SimCadenceController/Public/SimCadenceControllerModule.h Source/SimCadenceController/Public/SimCadenceSettings.h Source/SimCadenceController/SimCadenceController.Build.cs`


------
https://chatgpt.com/codex/tasks/task_b_689ede67b48483278fa75c577d99186c