### PR TITLE
fix: correct SimCadence include paths

### DIFF
--- a/Source/UnrealMLAgents/Private/Academy.cpp
+++ b/Source/UnrealMLAgents/Private/Academy.cpp
@@ -11,9 +11,8 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/CommandLine.h"
 #include "Engine/Engine.h"
-#include "SimCadenceController/SimCadenceEngineSubsystem.h"
-#include "SimCadenceController/SimCadencePhysicsBridge.h"
-
+#include "SimCadenceEngineSubsystem.h"
+#include "SimCadencePhysicsBridge.h"
 
 UAcademy* UAcademy::Instance = nullptr;
 


### PR DESCRIPTION
## Summary
- fix incorrect SimCadence include paths in Academy.cpp so plugin compiles without SimCadenceController directory prefix

## Testing
- `pre-commit run --files Source/UnrealMLAgents/Private/Academy.cpp`


------
https://chatgpt.com/codex/tasks/task_b_689eecefa0ec8327b3bf0a6bacc8abec