### PR TITLE
fix: guard TrainingEditorEngine for editor build

### DIFF
--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,4 +1,4 @@
-#if WITH_EDITOR
+#if WITH_EDITOR && UE_EDITOR
 	#include "TrainingEditorEngine.h"
 	#include "SimCadenceEngineSubsystem.h"
 	#include "Engine/Engine.h"
@@ -12,4 +12,4 @@ void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
 	}
 	Super::RedrawViewports(bPresent);
 }
-#endif // WITH_EDITOR
+#endif // WITH_EDITOR && UE_EDITOR

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,5 +1,6 @@
-#if WITH_EDITOR
-	#pragma once
+#pragma once
+
+#if WITH_EDITOR && UE_EDITOR
 	#include "CoreMinimal.h"
 	#include "Editor/EditorEngine.h"
 	#include "TrainingEditorEngine.generated.h"
@@ -8,7 +9,8 @@ UCLASS(config = Engine)
 class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
 {
 	GENERATED_BODY()
+
 protected:
 	virtual void RedrawViewports(bool bShouldPresent) override;
 };
-#endif // WITH_EDITOR
+#endif // WITH_EDITOR && UE_EDITOR

--- a/Source/UnrealMLAgents/Private/Academy.cpp
+++ b/Source/UnrealMLAgents/Private/Academy.cpp
@@ -11,9 +11,8 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/CommandLine.h"
 #include "Engine/Engine.h"
-#include "SimCadenceController/SimCadenceEngineSubsystem.h"
-#include "SimCadenceController/SimCadencePhysicsBridge.h"
-
+#include "SimCadenceEngineSubsystem.h"
+#include "SimCadencePhysicsBridge.h"
 
 UAcademy* UAcademy::Instance = nullptr;
 


### PR DESCRIPTION
## Summary
- fix incorrect SimCadence include paths in Academy.cpp so plugin compiles without SimCadenceController directory prefix
- guard TrainingEditorEngine with editor-only macro to avoid UEditorEngine dependency in non-editor builds

## Testing
- `pre-commit run --files Source/UnrealMLAgents/Private/Academy.cpp`
- `pre-commit run --files Source/SimCadenceController/Public/TrainingEditorEngine.h Source/SimCadenceController/Private/TrainingEditorEngine.cpp`


------
https://chatgpt.com/codex/tasks/task_b_689eecefa0ec8327b3bf0a6bacc8abec