### PR TITLE
fix: gate TrainingEditorEngine with custom macro

### DIFF
--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,5 +1,6 @@
-#if WITH_EDITOR
-	#include "TrainingEditorEngine.h"
+#include "TrainingEditorEngine.h"
+
+#if WITH_SIMCADENCE_TRAINING_ENGINE
 	#include "SimCadenceEngineSubsystem.h"
 	#include "Engine/Engine.h"
 
@@ -12,4 +13,4 @@ void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
 	}
 	Super::RedrawViewports(bPresent);
 }
-#endif // WITH_EDITOR
+#endif // WITH_SIMCADENCE_TRAINING_ENGINE

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,6 +1,8 @@
-#if WITH_EDITOR
-	#pragma once
-	#include "CoreMinimal.h"
+#pragma once
+
+#include "CoreMinimal.h"
+
+#if WITH_SIMCADENCE_TRAINING_ENGINE
 	#include "Editor/EditorEngine.h"
 	#include "TrainingEditorEngine.generated.h"
 
@@ -8,7 +10,8 @@ UCLASS(config = Engine)
 class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
 {
 	GENERATED_BODY()
+
 protected:
 	virtual void RedrawViewports(bool bShouldPresent) override;
 };
-#endif // WITH_EDITOR
+#endif // WITH_SIMCADENCE_TRAINING_ENGINE

--- a/Source/SimCadenceController/SimCadenceController.Build.cs
+++ b/Source/SimCadenceController/SimCadenceController.Build.cs
@@ -15,6 +15,11 @@ public class SimCadenceController : ModuleRules
 		if (Target.bBuildEditor)
 		{
 			PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd", "Settings" });
+			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=1");
+		}
+		else
+		{
+			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=0");
 		}
 	}
 }

--- a/Source/UnrealMLAgents/Private/Academy.cpp
+++ b/Source/UnrealMLAgents/Private/Academy.cpp
@@ -11,9 +11,8 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/CommandLine.h"
 #include "Engine/Engine.h"
-#include "SimCadenceController/SimCadenceEngineSubsystem.h"
-#include "SimCadenceController/SimCadencePhysicsBridge.h"
-
+#include "SimCadenceEngineSubsystem.h"
+#include "SimCadencePhysicsBridge.h"
 
 UAcademy* UAcademy::Instance = nullptr;
 


### PR DESCRIPTION
## Summary
- add build definition `WITH_SIMCADENCE_TRAINING_ENGINE` so TrainingEditorEngine only compiles in editor builds
- wrap TrainingEditorEngine class and implementation with this macro to avoid UEditorEngine dependency in game targets

## Testing
- `pre-commit run --files Source/SimCadenceController/SimCadenceController.Build.cs Source/SimCadenceController/Public/TrainingEditorEngine.h Source/SimCadenceController/Private/TrainingEditorEngine.cpp`


------
https://chatgpt.com/codex/tasks/task_b_689eecefa0ec8327b3bf0a6bacc8abec