### PR TITLE
Guard training engine for runtime builds and fix SimCadence includes

### DIFF
--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,5 +1,6 @@
-#if WITH_EDITOR
-	#include "TrainingEditorEngine.h"
+#include "TrainingEditorEngine.h"
+
+#if WITH_SIMCADENCE_TRAINING_ENGINE
 	#include "SimCadenceEngineSubsystem.h"
 	#include "Engine/Engine.h"
 
@@ -12,4 +13,4 @@ void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
 	}
 	Super::RedrawViewports(bPresent);
 }
-#endif // WITH_EDITOR
+#endif // WITH_SIMCADENCE_TRAINING_ENGINE

--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,6 +1,5 @@
-#include "TrainingEditorEngine.h"
-
-#if WITH_SIMCADENCE_TRAINING_ENGINE
+#if WITH_EDITOR && UE_EDITOR
+	#include "TrainingEditorEngine.h"
 	#include "SimCadenceEngineSubsystem.h"
 	#include "Engine/Engine.h"
 
@@ -13,4 +12,4 @@ void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
 	}
 	Super::RedrawViewports(bPresent);
 }
-#endif // WITH_SIMCADENCE_TRAINING_ENGINE
+#endif // WITH_EDITOR && UE_EDITOR

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "CoreMinimal.h"
-
-#if WITH_SIMCADENCE_TRAINING_ENGINE
+#if WITH_EDITOR && UE_EDITOR
+	#include "CoreMinimal.h"
 	#include "Editor/EditorEngine.h"
 	#include "TrainingEditorEngine.generated.h"
 
@@ -14,4 +13,4 @@ class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
 protected:
 	virtual void RedrawViewports(bool bShouldPresent) override;
 };
-#endif // WITH_SIMCADENCE_TRAINING_ENGINE
+#endif // WITH_EDITOR && UE_EDITOR

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,6 +1,8 @@
-#if WITH_EDITOR
-	#pragma once
-	#include "CoreMinimal.h"
+#pragma once
+
+#include "CoreMinimal.h"
+
+#if WITH_SIMCADENCE_TRAINING_ENGINE
 	#include "Editor/EditorEngine.h"
 	#include "TrainingEditorEngine.generated.h"
 
@@ -8,7 +10,8 @@ UCLASS(config = Engine)
 class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
 {
 	GENERATED_BODY()
+
 protected:
 	virtual void RedrawViewports(bool bShouldPresent) override;
 };
-#endif // WITH_EDITOR
+#endif // WITH_SIMCADENCE_TRAINING_ENGINE

--- a/Source/SimCadenceController/SimCadenceController.Build.cs
+++ b/Source/SimCadenceController/SimCadenceController.Build.cs
@@ -15,6 +15,11 @@ public class SimCadenceController : ModuleRules
 		if (Target.bBuildEditor)
 		{
 			PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd", "Settings" });
+			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=1");
+		}
+		else
+		{
+			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=0");
 		}
 	}
 }

--- a/Source/SimCadenceController/SimCadenceController.Build.cs
+++ b/Source/SimCadenceController/SimCadenceController.Build.cs
@@ -15,11 +15,6 @@ public class SimCadenceController : ModuleRules
 		if (Target.bBuildEditor)
 		{
 			PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd", "Settings" });
-			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=1");
-		}
-		else
-		{
-			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=0");
 		}
 	}
 }

--- a/Source/UnrealMLAgents/Private/Academy.cpp
+++ b/Source/UnrealMLAgents/Private/Academy.cpp
@@ -11,9 +11,8 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/CommandLine.h"
 #include "Engine/Engine.h"
-#include "SimCadenceController/SimCadenceEngineSubsystem.h"
-#include "SimCadenceController/SimCadencePhysicsBridge.h"
-
+#include "SimCadenceEngineSubsystem.h"
+#include "SimCadencePhysicsBridge.h"
 
 UAcademy* UAcademy::Instance = nullptr;
 
@@ -103,7 +102,7 @@ void UAcademy::ParseCommandLineArgs()
 
 void UAcademy::InitializeEnvironment()
 {
-	UE_LOG(LogTemp, Log, TEXT("Initialize Environement"));
+	UE_LOG(LogTemp, Log, TEXT("Initialize Environment"));
 
 	bEnableStepping = true;
 	ParseCommandLineArgs();


### PR DESCRIPTION
## Summary
- Guard `UTrainingEditorEngine` behind `WITH_SIMCADENCE_TRAINING_ENGINE` so packaged games avoid `UEditorEngine` references
- Include `SimCadenceEngineSubsystem` and `SimCadencePhysicsBridge` directly in `UAcademy`
- Define `WITH_SIMCADENCE_TRAINING_ENGINE` in build script when compiling with the editor
- Correct "Initialize Environment" log spelling

## Testing
- `pre-commit run --files Source/UnrealMLAgents/Private/Academy.cpp Source/SimCadenceController/Public/TrainingEditorEngine.h Source/SimCadenceController/Private/TrainingEditorEngine.cpp Source/SimCadenceController/SimCadenceController.Build.cs`


------
https://chatgpt.com/codex/tasks/task_b_689eecefa0ec8327b3bf0a6bacc8abec