### PR TITLE
Fix training editor engine macro usage

### DIFF
--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,16 +1,17 @@
+#include "TrainingEditorEngine.h"
+
 #if WITH_SIMCADENCE_TRAINING_ENGINE
-	#include "TrainingEditorEngine.h"
-	#include "SimCadenceEngineSubsystem.h"
-	#include "Engine/Engine.h"
+#include "SimCadenceEngineSubsystem.h"
+#include "Engine/Engine.h"
 
 void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
 {
-	bool bPresent = bShouldPresent;
-	if (USimCadenceEngineSubsystem* Sub = GEngine ? GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>() : nullptr)
-	{
-		bPresent = Sub->ShouldSubmitFrame();
-	}
-	Super::RedrawViewports(bPresent);
+    bool bPresent = bShouldPresent;
+    if (USimCadenceEngineSubsystem* Sub = GEngine ? GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>() : nullptr)
+    {
+        bPresent = Sub->ShouldSubmitFrame();
+    }
+    Super::RedrawViewports(bPresent);
 }
 
 #endif // WITH_SIMCADENCE_TRAINING_ENGINE

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#if WITH_SIMCADENCE_TRAINING_ENGINE
-	#include "CoreMinimal.h"
-	#include "Editor/EditorEngine.h"
-	#include "TrainingEditorEngine.generated.h"
+#include "CoreMinimal.h"
+#include "Editor/EditorEngine.h"
+#include "TrainingEditorEngine.generated.h"
 
 UCLASS(config = Engine)
 class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
 {
-	GENERATED_BODY()
+    GENERATED_BODY()
 
 protected:
-	virtual void RedrawViewports(bool bShouldPresent) override;
+#if WITH_SIMCADENCE_TRAINING_ENGINE
+    virtual void RedrawViewports(bool bShouldPresent) override;
+#endif
 };
 
-#endif // WITH_SIMCADENCE_TRAINING_ENGINE


### PR DESCRIPTION
## Summary
- fix UTrainingEditorEngine declaration so `UCLASS` isn't inside preprocessor guard
- adjust TrainingEditorEngine.cpp to wrap method implementation with `WITH_SIMCADENCE_TRAINING_ENGINE`

## Testing
- `pytest` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_689fc40b817483278f7e34e5990441c4