### PR TITLE
refactor: clarify training engine base

### DIFF
--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -3,10 +3,10 @@
 #include "CoreMinimal.h"
 #if WITH_SIMCADENCE_TRAINING_ENGINE
 #include "Editor/EditorEngine.h"
-#define UTrainingEditorEngineBase UEditorEngine
+using UTrainingEditorEngineBase = UEditorEngine;
 #else
 #include "Engine/Engine.h"
-#define UTrainingEditorEngineBase UEngine
+using UTrainingEditorEngineBase = UEngine;
 #endif
 
 #include "TrainingEditorEngine.generated.h"
@@ -21,6 +21,4 @@ protected:
     virtual void RedrawViewports(bool bShouldPresent) override;
 #endif
 };
-
-#undef UTrainingEditorEngineBase
 


### PR DESCRIPTION
## Summary
- use type alias to select editor or engine base for TrainingEditorEngine

## Testing
- `/opt/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildPlugin -Plugin=/workspace/UnrealMLAgentsPT/UnrealMLAgents.uplugin -Package=/workspace/UnrealMLAgentsPT/PackagedPlugin` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689fd461db2c8327bee200e5762bf4f5