### PR TITLE
Refactor training engine header for conditional base alias

### DIFF
--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -4,23 +4,21 @@
 
 #if WITH_SIMCADENCE_TRAINING_ENGINE
 	#include "Editor/EditorEngine.h"
-	#include "TrainingEditorEngine.generated.h"
-
-UCLASS(config = Engine)
-class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEditorEngine
-{
-	GENERATED_BODY()
-
-protected:
-	virtual void RedrawViewports(bool bShouldPresent) override;
-};
+using FTrainingEditorEngineSuper = UEditorEngine;
 #else
 	#include "Engine/Engine.h"
-	#include "TrainingEditorEngine.generated.h"
+using FTrainingEditorEngineSuper = UEngine;
+#endif
+
+#include "TrainingEditorEngine.generated.h"
 
 UCLASS(config = Engine)
-class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UEngine
+class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public FTrainingEditorEngineSuper
 {
 	GENERATED_BODY()
-};
+
+#if WITH_SIMCADENCE_TRAINING_ENGINE
+protected:
+	virtual void RedrawViewports(bool bShouldPresent) override;
 #endif
+};


### PR DESCRIPTION
## Summary
- Select engine base class via alias to keep UCLASS outside conditionals
- Guard `RedrawViewports` override for training builds

## Testing
- `pre-commit run --files Source/SimCadenceController/Public/TrainingEditorEngine.h`
- `RunUAT BuildPlugin -Plugin="$(pwd)/UnrealMLAgents.uplugin" -Package="/tmp/Build" -TargetPlatforms=Win64` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689fde8680ac83278cf5063830e8db95