### PR TITLE
Use macro for training editor engine inheritance

### DIFF
--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -3,17 +3,21 @@
 #include "CoreMinimal.h"
 
 #if WITH_SIMCADENCE_TRAINING_ENGINE
-	#include "Editor/EditorEngine.h"
-using FTrainingEditorEngineSuper = UEditorEngine;
+        #include "UnrealEd/UnrealEdEngine.h"
+        #if (ENGINE_MAJOR_VERSION >= 5)
+                #define TRAINING_EDITOR_ENGINE_SUPER UUnrealEdEngine
+        #else
+                #define TRAINING_EDITOR_ENGINE_SUPER UEditorEngine
+        #endif
 #else
-	#include "Engine/Engine.h"
-using FTrainingEditorEngineSuper = UEngine;
+        #include "Engine/Engine.h"
+        #define TRAINING_EDITOR_ENGINE_SUPER UEngine
 #endif
 
 #include "TrainingEditorEngine.generated.h"
 
 UCLASS(config = Engine)
-class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public FTrainingEditorEngineSuper
+class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public TRAINING_EDITOR_ENGINE_SUPER
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
## Summary
- add TRAINING_EDITOR_ENGINE_SUPER macro to select proper editor engine class
- inherit UTrainingEditorEngine from TRAINING_EDITOR_ENGINE_SUPER

## Testing
- `pytest` *(fails: No module named 'cattr' and 'ueagents_envs')*


------
https://chatgpt.com/codex/tasks/task_b_689ff48d260c832797f64f67aef75483