### PR TITLE
Fix TrainingEditorEngine inheritance for UE 5.5

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -1,7 +1,5 @@
 [/Script/Engine.Engine]
 GameEngine=/Script/SimCadenceController.TrainingGameEngine
-
-[/Script/UnrealEd.EditorEngine]
-EditorEngine=/Script/SimCadenceController.TrainingEditorEngine
+UnrealEdEngine=/Script/SimCadenceController.TrainingEditorEngine
 
 r.VSyncEditor=0

--- a/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
+++ b/Source/SimCadenceController/Private/TrainingEditorEngine.cpp
@@ -1,17 +1,23 @@
 #include "TrainingEditorEngine.h"
-
-#if WITH_SIMCADENCE_TRAINING_ENGINE
 #include "SimCadenceEngineSubsystem.h"
 #include "Engine/Engine.h"
 
-void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
+void UTrainingEditorEngine::Init(IEngineLoop* InEngineLoop)
 {
-    bool bPresent = bShouldPresent;
-    if (USimCadenceEngineSubsystem* Sub = GEngine ? GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>() : nullptr)
-    {
-        bPresent = Sub->ShouldSubmitFrame();
-    }
-    Super::RedrawViewports(bPresent);
+	Super::Init(InEngineLoop);
 }
 
-#endif // WITH_SIMCADENCE_TRAINING_ENGINE
+void UTrainingEditorEngine::Tick(float DeltaSeconds, bool bIdleMode)
+{
+	Super::Tick(DeltaSeconds, bIdleMode);
+}
+
+void UTrainingEditorEngine::RedrawViewports(bool bShouldPresent)
+{
+	bool bPresent = bShouldPresent;
+	if (USimCadenceEngineSubsystem* Sub = GEngine ? GEngine->GetEngineSubsystem<USimCadenceEngineSubsystem>() : nullptr)
+	{
+		bPresent = Sub->ShouldSubmitFrame();
+	}
+	Super::RedrawViewports(bPresent);
+}

--- a/Source/SimCadenceController/Public/TrainingEditorEngine.h
+++ b/Source/SimCadenceController/Public/TrainingEditorEngine.h
@@ -1,28 +1,20 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
-#if WITH_SIMCADENCE_TRAINING_ENGINE
-        #include "UnrealEd/UnrealEdEngine.h"
-        #if (ENGINE_MAJOR_VERSION >= 5)
-                #define TRAINING_EDITOR_ENGINE_SUPER UUnrealEdEngine
-        #else
-                #define TRAINING_EDITOR_ENGINE_SUPER UEditorEngine
-        #endif
-#else
-        #include "Engine/Engine.h"
-        #define TRAINING_EDITOR_ENGINE_SUPER UEngine
-#endif
-
+#include "Editor/UnrealEdEngine.h"
 #include "TrainingEditorEngine.generated.h"
 
-UCLASS(config = Engine)
-class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public TRAINING_EDITOR_ENGINE_SUPER
+class IEngineLoop;
+
+UCLASS(Config = Engine, Transient)
+class SIMCADENCECONTROLLER_API UTrainingEditorEngine : public UUnrealEdEngine
 {
 	GENERATED_BODY()
 
-#if WITH_SIMCADENCE_TRAINING_ENGINE
+public:
+	virtual void Init(IEngineLoop* InEngineLoop) override;
+	virtual void Tick(float DeltaSeconds, bool bIdleMode) override;
+
 protected:
 	virtual void RedrawViewports(bool bShouldPresent) override;
-#endif
 };

--- a/Source/SimCadenceController/SimCadenceController.Build.cs
+++ b/Source/SimCadenceController/SimCadenceController.Build.cs
@@ -6,20 +6,13 @@ public class SimCadenceController : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-		PublicDependencyModuleNames.AddRange(
-			new string[] { "Core", "CoreUObject", "Engine", "Projects", "DeveloperSettings" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "DeveloperSettings" });
 
-		PrivateDependencyModuleNames.AddRange(
-			new string[] { "Slate", "SlateCore", "InputCore", "RenderCore", "RHI", "PhysicsCore" });
+		PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd", "Slate", "SlateCore", "Projects" });
 
-		if (Target.bBuildEditor)
+		if (!Target.bBuildEditor)
 		{
-			PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd", "Settings", "EditorFramework" });
-			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=1");
-		}
-		else
-		{
-			PublicDefinitions.Add("WITH_SIMCADENCE_TRAINING_ENGINE=0");
+			throw new BuildException("SimCadenceController must be built with the editor.");
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- inherit `UTrainingEditorEngine` directly from `UUnrealEdEngine`
- require `UnrealEd` and editor-only build for SimCadenceController module
- use `UnrealEdEngine` in config to activate custom editor engine

## Testing
- `pytest MLearning/ue-agents/ueagents/trainers/tests/test_agent_processor.py::test_agent_processor_get_actions -q` *(fails: No module named 'h5py')*

------
https://chatgpt.com/codex/tasks/task_b_689ff8b4a73c83279d31dfbf6992e74e